### PR TITLE
chore: update to ttsky template

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-ARG VARIANT=ubuntu-22.04
+ARG VARIANT=ubuntu-24.04
 FROM mcr.microsoft.com/vscode/devcontainers/base:${VARIANT}
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -10,18 +10,19 @@ RUN apt install -y iverilog gtkwave python3 python3-pip python3-venv python3-tk 
 
 # Clone tt-support-tools
 RUN mkdir -p /ttsetup
-RUN git clone -b tt10 https://github.com/TinyTapeout/tt-support-tools /ttsetup/tt-support-tools
+RUN git clone https://github.com/TinyTapeout/tt-support-tools /ttsetup/tt-support-tools
 
 COPY test/requirements.txt /ttsetup/test_requirements.txt
 COPY .devcontainer/copy_tt_support_tools.sh /ttsetup
 
-RUN pip3 install -r /ttsetup/test_requirements.txt -r /ttsetup/tt-support-tools/requirements.txt
+RUN python -m venv /ttsetup/venv
+RUN /ttsetup/venv/bin/pip install -r /ttsetup/test_requirements.txt -r /ttsetup/tt-support-tools/requirements.txt
 
 # Install verible (for formatting)
 RUN umask 022 && \
-    curl -L https://github.com/chipsalliance/verible/releases/download/v0.0-3795-gf4d72375/verible-v0.0-3795-gf4d72375-linux-static-x86_64.tar.gz | \
+    curl -L https://github.com/chipsalliance/verible/releases/download/v0.0-4023-gc1271a00/verible-v0.0-4023-gc1271a00-linux-static-x86_64.tar.gz | \
     tar zxf - -C /usr/local --strip-components=1 && \
     chmod 755 /usr/local/bin
 
-# Install openlane
-RUN pip3 install openlane==2.1.5
+# Install LibreLane
+RUN /ttsetup/venv/bin/pip install librelane==2.4.2

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -25,5 +25,6 @@
       "dockerDashComposeVersion": "none"
     }
   },
+  "postCreateCommand": "echo 'source /ttsetup/venv/bin/activate' >> ~/.bashrc",
   "postStartCommand": "/ttsetup/copy_tt_support_tools.sh"
 }

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -14,4 +14,4 @@ jobs:
           submodules: recursive
 
       - name: Build docs
-        uses: TinyTapeout/tt-gds-action/docs@tt10
+        uses: TinyTapeout/tt-gds-action/docs@ttsky25b

--- a/.github/workflows/fpga.yaml
+++ b/.github/workflows/fpga.yaml
@@ -16,4 +16,4 @@ jobs:
           submodules: recursive
 
       - name: FPGA bitstream for TT ASIC Sim (ICE40UP5K)
-        uses: TinyTapeout/tt-gds-action/fpga/ice40up5k@tt10
+        uses: TinyTapeout/tt-gds-action/fpga/ice40up5k@ttsky25b

--- a/.github/workflows/gds.yaml
+++ b/.github/workflows/gds.yaml
@@ -14,16 +14,16 @@ jobs:
           submodules: recursive
 
       - name: Build GDS
-        uses: TinyTapeout/tt-gds-action@tt10
+        uses: TinyTapeout/tt-gds-action@ttsky25b
         with:
-          flow: openlane2
+          pdk: sky130A
 
   precheck:
     needs: gds
     runs-on: ubuntu-24.04
     steps:
       - name: Run Tiny Tapeout Precheck
-        uses: TinyTapeout/tt-gds-action/precheck@tt10
+        uses: TinyTapeout/tt-gds-action/precheck@ttsky25b
 
   gl_test:
     needs: gds
@@ -35,7 +35,7 @@ jobs:
           submodules: recursive
 
       - name: GL test
-        uses: TinyTapeout/tt-gds-action/gl_test@tt10
+        uses: TinyTapeout/tt-gds-action/gl_test@ttsky25b
 
   viewer:
     needs: gds
@@ -44,4 +44,4 @@ jobs:
       pages: write      # to deploy to Pages
       id-token: write   # to verify the deployment originates from an appropriate source
     steps:
-      - uses: TinyTapeout/tt-gds-action/viewer@tt10
+      - uses: TinyTapeout/tt-gds-action/viewer@ttsky25b

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -45,3 +45,4 @@ jobs:
           path: |
             test/tb.vcd
             test/results.xml
+            test/output/*

--- a/src/config.json
+++ b/src/config.json
@@ -31,7 +31,7 @@
   "//": "https://tinytapeout.com/faq/#how-can-i-map-an-additional-external-clock-to-one-of-the-gpios",
   "CLOCK_PORT": "clk",
 
-  "//": "Configuration docs: https://openlane.readthedocs.io/en/latest/reference/configuration.html",
+  "//": "Configuration docs: https://librelane.readthedocs.io/en/latest/reference/configuration.html",
 
   "//": "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!",
   "//": "!!! DO NOT CHANGE ANYTHING BELOW THIS POINT !!!",
@@ -63,9 +63,8 @@
   "//": "Clock",
   "RUN_CTS": 1,
 
-  "//": "Don't use power rings or met5 layer",
+  "//": "Don't generate power rings",
   "FP_PDN_MULTILAYER": 0,
-  "RT_MAX_LAYER": "met4",
 
   "//": "MAGIC_DEF_LABELS may cause issues with LVS",
   "MAGIC_DEF_LABELS": 0,

--- a/test/Makefile
+++ b/test/Makefile
@@ -3,6 +3,7 @@
 
 # defaults
 SIM ?= icarus
+WAVES ?= 1
 TOPLEVEL_LANG ?= verilog
 SRC_DIR = $(PWD)/../src
 PROJECT_SOURCES = project.v
@@ -37,8 +38,8 @@ COMPILE_ARGS 		+= -I$(SRC_DIR)
 VERILOG_SOURCES += $(PWD)/tb.v
 TOPLEVEL = tb
 
-# MODULE is the basename of the Python test file
-MODULE = test
+# List test modules to run, separated by commas and without the .py suffix:
+COCOTB_TEST_MODULES = test
 
 # include cocotb's make rules to take care of the simulator setup
 include $(shell cocotb-config --makefiles)/Makefile.sim

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,2 +1,2 @@
-pytest==8.3.4
-cocotb==1.9.2
+pytest==8.4.2
+cocotb==2.0.0

--- a/test/test.py
+++ b/test/test.py
@@ -10,11 +10,11 @@ from cocotb.types import LogicArray
 
 async def await_half_sclk(dut):
     """Wait for the SCLK signal to go high or low."""
-    start_time = cocotb.utils.get_sim_time(units="ns")
+    start_time = cocotb.utils.get_sim_time(unit="ns")
     while True:
         await ClockCycles(dut.clk, 1)
         # Wait for half of the SCLK period (10 us)
-        if (start_time + 100*100*0.5) < cocotb.utils.get_sim_time(units="ns"):
+        if (start_time + 100*100*0.5) < cocotb.utils.get_sim_time(unit="ns"):
             break
     return
 
@@ -28,7 +28,7 @@ async def send_spi_transaction(dut, r_w, address, data):
     - 1 bit for Read/Write
     - 7 bits for address
     - 8 bits for data
-    
+
     Parameters:
     - r_w: boolean, True for write, False for read
     - address: int, 7-bit address (0-127)
@@ -88,7 +88,7 @@ async def test_spi(dut):
     dut._log.info("Start SPI test")
 
     # Set the clock period to 100 ns (10 MHz)
-    clock = Clock(dut.clk, 100, units="ns")
+    clock = Clock(dut.clk, 100, unit="ns")
     cocotb.start_soon(clock.start())
 
     # Reset
@@ -122,7 +122,7 @@ async def test_spi(dut):
     ui_in_val = await send_spi_transaction(dut, 0, 0x30, 0xBE)
     assert dut.uo_out.value == 0xF0, f"Expected 0xF0, got {dut.uo_out.value}"
     await ClockCycles(dut.clk, 100)
-    
+
     dut._log.info("Read transaction (invalid), address 0x41 (invalid), data 0xEF")
     ui_in_val = await send_spi_transaction(dut, 0, 0x41, 0xEF)
     await ClockCycles(dut.clk, 100)


### PR DESCRIPTION
[tt10-verilog-template](https://github.com/TinyTapeout/tt10-verilog-template) is discontinued as tt10 was cancelled, and I see we already use the new template in projects like [Crypto-SHA](https://github.com/UW-ASIC/Crypto-SHA)

As per TinyTapeout's recommendation, import upstream from [ttsky-verilog-template](https://github.com/TinyTapeout/ttsky-verilog-template).